### PR TITLE
Threads producing gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,21 @@ kafka.brokers = my_test_kafka:9092
 EOF
 ```
 
+### Automagical topic name generation
+
+If you set `default_topic_prefix` in `~/.kafka-partition-availability-benchmark.properties`, the
+client will attempt to perform a lookup of your hostname and use that instead.  This may fail because
+your DNS resolver isn't configured properly, or your hostname doesn't exist in `/etc/hosts`.  Caveat emptor.
+
+### Tuning
+
 Depending on how powerful your test runner host is, you might be able to bump up the number of topics past `4000`. In
 our testing, `4000` was what an i3.2xlarge instance could bear before test results started to get skewed. 
 
 To get past `4000` topics, we ran this tool on multiple test runners. We recommend setting the default topic prefix to 
 something unique per test runner by doing something like this:
 ```
-echo "default_topic_prefix = `hostname`" >> ~/.kafka-partition-availability-benchmark.properties
+echo "default_topic_prefix = use_hostname" >> ~/.kafka-partition-availability-benchmark.properties
 ```
 
 ### Measuring produce and consume at the same time
@@ -67,3 +75,6 @@ for test_runner in ${test_runners}; do
     ssh ${test_runner} 'for pr in `pgrep -f kafka_partition_availability_benchmark`; do sudo prlimit -n50000:50000 -p $pr; done';
 done
 ```
+
+However, it is highly suggested you increase the number of open file handles by setting the values in
+`/etc/security/limits.conf` before launching this utility.

--- a/dashboards/Kafka Partition Availability Benchmark.json
+++ b/dashboards/Kafka Partition Availability Benchmark.json
@@ -23,6 +23,12 @@
       "version": ""
     },
     {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
@@ -48,7 +54,7 @@
   "hideControls": false,
   "id": null,
   "links": [],
-  "refresh": false,
+  "refresh": "5s",
   "rows": [
     {
       "collapse": false,
@@ -83,7 +89,9 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {}
+          ],
           "spaceLength": 10,
           "span": 6,
           "stack": false,
@@ -308,7 +316,12 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "WriteTopicErrorCounts",
+              "yaxis": 2
+            }
+          ],
           "spaceLength": 10,
           "span": 6,
           "stack": false,
@@ -338,11 +351,32 @@
               "refId": "C"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(produceMessageTimeSecs_bucket) by (le))",
+              "expr": "histogram_quantile(0.95, sum(produceMessageTimeSecs_bucket) by (le))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "99%ile produce message ",
+              "legendFormat": "95%ile produce message ",
               "refId": "D"
+            },
+            {
+              "expr": "avg(histogram_quantile(0.95, firstMessageProduceTimeSecs_bucket))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "First Message 95th%",
+              "refId": "E"
+            },
+            {
+              "expr": "avg(summaryFirstMessageProduceTimeSecs_sum / summaryFirstMessageProduceTimeSecs_count)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Summary First Message Produce Time",
+              "refId": "F"
+            },
+            {
+              "expr": "sum(writeTopicErrorCounts)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "WriteTopicErrorCounts",
+              "refId": "G"
             }
           ],
           "thresholds": [],
@@ -364,7 +398,7 @@
           },
           "yaxes": [
             {
-              "format": "s",
+              "format": "ms",
               "label": "Seconds",
               "logBase": 1,
               "max": null,
@@ -372,12 +406,12 @@
               "show": true
             },
             {
-              "format": "s",
+              "format": "short",
               "label": "",
               "logBase": 1,
               "max": null,
               "min": null,
-              "show": false
+              "show": true
             }
           ]
         },
@@ -408,7 +442,16 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "Producer Count",
+              "yaxis": 2
+            },
+            {
+              "alias": "50 ms sla",
+              "fill": 0
+            }
+          ],
           "spaceLength": 10,
           "span": 6,
           "stack": false,
@@ -417,6 +460,7 @@
             {
               "expr": "avg(consumerReceiveTimeSecs_sum / consumerReceiveTimeSecs_count)",
               "format": "time_series",
+              "hide": false,
               "intervalFactor": 2,
               "legendFormat": "Consume latencies",
               "refId": "A"
@@ -424,23 +468,39 @@
             {
               "expr": "avg(consumerCommitTimeSecs_sum / consumerCommitTimeSecs_count)",
               "format": "time_series",
+              "hide": true,
               "intervalFactor": 2,
               "legendFormat": "Commit latencies",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(consumerReceiveTimeSecs_bucket[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(consumerReceiveTimeSecs_bucket[5m])) by (le))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "99th percentile consume latency",
+              "legendFormat": "95th percentile consume latency",
               "refId": "F"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(consumerCommitTimeSecs_bucket[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(consumerCommitTimeSecs_bucket[5m])) by (le))",
+              "format": "time_series",
+              "hide": true,
+              "intervalFactor": 2,
+              "legendFormat": "95th percentile commit latency",
+              "refId": "G"
+            },
+            {
+              "expr": "count(jvm_info{job=\"producer\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "99th percentile commit latency",
-              "refId": "G"
+              "legendFormat": "Producer Count",
+              "refId": "C"
+            },
+            {
+              "expr": ".050",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "50 ms sla",
+              "refId": "D"
             }
           ],
           "thresholds": [],
@@ -470,8 +530,8 @@
               "show": true
             },
             {
-              "format": "s",
-              "label": "",
+              "format": "short",
+              "label": "count",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -519,49 +579,62 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "ZK Min",
+              "yaxis": 2
+            },
+            {
+              "alias": "ZK 5 Min",
+              "yaxis": 2
+            },
+            {
+              "alias": "ZK 15 Min",
+              "yaxis": 2
+            }
+          ],
           "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(node_load1{job=~\"kafka-sys-.+\"})",
+              "expr": "avg(node_load1{job=\"kafka-sys\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Kafka Load Average Min",
               "refId": "A"
             },
             {
-              "expr": "avg(node_load5{job=~\"kafka-sys-.+\"})",
+              "expr": "avg(node_load5{job=\"kafka-sys\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Kafka Load Average 5 Min",
               "refId": "B"
             },
             {
-              "expr": "avg(node_load15{job=~\"kafka-sys-.+\"})",
+              "expr": "avg(node_load15{job=\"kafka-sys\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Kafka Load Average 15 Min",
               "refId": "C"
             },
             {
-              "expr": "avg(node_load1{job=~\"zoo-sys-.+\"})",
+              "expr": "avg(node_load1{job=\"zoo-sys\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "ZK Min",
               "refId": "D"
             },
             {
-              "expr": "avg(node_load5{job=~\"zoo-sys-.+\"})",
+              "expr": "avg(node_load5{job=\"zoo-sys\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "ZK 5 Min",
               "refId": "E"
             },
             {
-              "expr": "avg(node_load15{job=~\"zoo-sys-.+\"})",
+              "expr": "avg(node_load15{job=\"zoo-sys\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "ZK 15 Min",
@@ -639,20 +712,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "kafka_controller_kafkacontroller_activecontrollercount{job=\"kafka-7\"}",
+              "expr": "max(kafka_controller_kafkacontroller_activecontrollercount{job=\"kafka\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
               "refId": "A"
             },
             {
-              "expr": "rate(kafka_network_requestmetrics_requestbytes{job=~\"kafka-.+\",request=\"Fetch\"}[1h])/3600",
+              "expr": "rate(kafka_network_requestmetrics_requestbytes{job=\"kafka\",request=\"Fetch\"}[1h])",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "B"
             },
             {
-              "expr": "sum(rate(kafka_network_requestmetrics_requestbytes{job=~\"kafka-.+\",request=\"Fetch\"}[1h])/3600)",
+              "expr": "sum(rate(kafka_network_requestmetrics_requestbytes{job=\"kafka\",request=\"Fetch\"}[1h])/3600)",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "C"
@@ -825,7 +898,16 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "Avg ZK network receive",
+              "yaxis": 2
+            },
+            {
+              "alias": "Avg ZK network transmit",
+              "yaxis": 2
+            }
+          ],
           "spaceLength": 10,
           "span": 6,
           "stack": false,
@@ -879,7 +961,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "Bps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -887,7 +969,7 @@
               "show": true
             },
             {
-              "format": "short",
+              "format": "Bps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -937,7 +1019,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 12,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -966,7 +1048,146 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Incremetnal Fetch Stats (KIP-227)",
+          "title": "Incremental Fetch Stats (KIP-227)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": "${DS_TEST}",
+          "heatmap": {},
+          "highlightCards": true,
+          "id": 10,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "span": 6,
+          "targets": [
+            {
+              "expr": "produceMessageTimeSecs_bucket/1200",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "title": "Produce message Time Buckets",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "µs",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketNumber": null,
+          "yBucketSize": null
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST}",
+          "fill": 1,
+          "id": 11,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Panel Title",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1015,7 +1236,7 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -1044,6 +1265,6 @@
     ]
   },
   "timezone": "",
-  "title": "Kafka Partition Availability Benchmark",
-  "version": 8
+  "title": "kafka-partition-availability-benchmark",
+  "version": 23
 }

--- a/src/main/java/com/salesforce/Main.java
+++ b/src/main/java/com/salesforce/Main.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -74,6 +75,16 @@ public class Main {
             System.exit(4);
         }
         String topicPrefix = settings.getProperty("default_topic_prefix");
+
+        if ( topicPrefix.contentEquals("use_hostname") ) {
+            try {
+                topicPrefix = java.net.InetAddress.getLocalHost().getHostName();
+            } catch ( UnknownHostException e ) {
+                // dns is broken :(
+                topicPrefix = "default";
+            }
+        }
+
         Integer readWriteIntervalMs = Integer.valueOf(settings.getProperty("read_write_interval_ms"));
 
         Integer numMessagesToSendPerBatch = Integer.valueOf(settings.getProperty("messages_per_batch"));

--- a/src/main/java/com/salesforce/Main.java
+++ b/src/main/java/com/salesforce/Main.java
@@ -76,12 +76,12 @@ public class Main {
         }
         String topicPrefix = settings.getProperty("default_topic_prefix");
 
-        if ( topicPrefix.contentEquals("use_hostname") ) {
+        if (topicPrefix.contentEquals("use_hostname")) {
             try {
                 topicPrefix = java.net.InetAddress.getLocalHost().getHostName();
             } catch ( UnknownHostException e ) {
-                // dns is broken :(
-                topicPrefix = "default";
+                log.warn("Unable to resolve DNS", e);
+                System.exit(1);
             }
         }
 

--- a/src/main/java/com/salesforce/Main.java
+++ b/src/main/java/com/salesforce/Main.java
@@ -79,8 +79,8 @@ public class Main {
         if (topicPrefix.contentEquals("use_hostname")) {
             try {
                 topicPrefix = java.net.InetAddress.getLocalHost().getHostName();
-            } catch ( UnknownHostException e ) {
-                log.warn("Unable to resolve DNS", e);
+            } catch (UnknownHostException unknownHost) {
+                log.warn("Unable to resolve DNS", unknownHost);
                 System.exit(1);
             }
         }

--- a/src/main/java/com/salesforce/PrometheusMetricsServer.java
+++ b/src/main/java/com/salesforce/PrometheusMetricsServer.java
@@ -7,6 +7,7 @@
 
 package com.salesforce;
 
+import io.prometheus.client.hotspot.DefaultExports;
 import io.prometheus.client.vertx.MetricsHandler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
@@ -20,10 +21,12 @@ public class PrometheusMetricsServer implements Runnable {
 
     public PrometheusMetricsServer(int port) {
         this.port = port;
+        DefaultExports.initialize();
     }
 
     @Override
     public void run() {
+
         Vertx vertx = Vertx.vertx();
         Router router = Router.router(vertx);
         router.route("/metrics").handler(new MetricsHandler());

--- a/src/main/java/com/salesforce/TopicVerifier.java
+++ b/src/main/java/com/salesforce/TopicVerifier.java
@@ -44,9 +44,18 @@ class TopicVerifier {
                 continue;
             }
             TopicPartitionInfo partition = descriptionMap.get(topicName).partitions().get(0);
+
+            /*
+            * If the replication factor is 2 or lower, we won't have more than 1 ISR - this is mostly
+            * for local testing purposes
+             */
+            int _isr_size = 1;
+            if (replicationFactor <= 2) {
+                _isr_size = 0;
+            }
             if (!partition.leader().isEmpty()
                     && partition.replicas().size() == replicationFactor
-                    && partition.isr().size() > 1) {
+                    && partition.isr().size() > _isr_size ) {
                 topicsCreated.dec();
                 break;
             } else {

--- a/src/main/java/com/salesforce/TopicVerifier.java
+++ b/src/main/java/com/salesforce/TopicVerifier.java
@@ -49,13 +49,13 @@ class TopicVerifier {
             * If the replication factor is 2 or lower, we won't have more than 1 ISR - this is mostly
             * for local testing purposes
              */
-            int _isrSize = 1;
+            int isrSize = 1;
             if (replicationFactor <= 2) {
-                _isrSize = 0;
+                isrSize = 0;
             }
             if (!partition.leader().isEmpty()
                     && partition.replicas().size() == replicationFactor
-                    && partition.isr().size() > _isrSize ) {
+                    && partition.isr().size() > isrSize ) {
                 topicsCreated.dec();
                 break;
             } else {

--- a/src/main/java/com/salesforce/TopicVerifier.java
+++ b/src/main/java/com/salesforce/TopicVerifier.java
@@ -49,13 +49,13 @@ class TopicVerifier {
             * If the replication factor is 2 or lower, we won't have more than 1 ISR - this is mostly
             * for local testing purposes
              */
-            int _isr_size = 1;
+            int _isrSize = 1;
             if (replicationFactor <= 2) {
-                _isr_size = 0;
+                _isrSize = 0;
             }
             if (!partition.leader().isEmpty()
                     && partition.replicas().size() == replicationFactor
-                    && partition.isr().size() > _isr_size ) {
+                    && partition.isr().size() > _isrSize ) {
                 topicsCreated.dec();
                 break;
             } else {

--- a/src/main/java/com/salesforce/WriteTopic.java
+++ b/src/main/java/com/salesforce/WriteTopic.java
@@ -145,7 +145,7 @@ class WriteTopic implements Callable<Exception> {
             if (error != null && recordMetadata != null) {
                 errorCounts.inc();
                 log.error("Callback failed for topic {}", recordMetadata.topic(), error);
-            } else if (error != null && recordMetadata == null) {
+            } else if (error != null) {
                 errorCounts.inc();
                 log.error("Callback failed", error);
             }

--- a/src/main/java/com/salesforce/WriteTopic.java
+++ b/src/main/java/com/salesforce/WriteTopic.java
@@ -128,9 +128,11 @@ class WriteTopic implements Callable<Exception> {
 
         @Override
         public void onCompletion(RecordMetadata recordMetadata, Exception error) {
-            if (e != null && ) {
+            if (error != null && recordMetadata != null) {
                 errorCounts.inc();
-                log.error("Callback failed for topic {}", recordMetadata.topic(), error);
+                log.error("Callback failed for first message on topic {}", recordMetadata.topic(), error);
+            } else if (error != null) {
+                log.error("Callback failed for first message", error);
             }
             requestTimer.observeDuration();
         }
@@ -140,10 +142,10 @@ class WriteTopic implements Callable<Exception> {
 
         @Override
         public void onCompletion(RecordMetadata recordMetadata, Exception error) {
-            if (e != null && RecordMetadata != null) {
+            if (error != null && recordMetadata != null) {
                 errorCounts.inc();
                 log.error("Callback failed for topic {}", recordMetadata.topic(), error);
-            } else if ( e != null && recordMetadata == null) {
+            } else if (error != null && recordMetadata == null) {
                 errorCounts.inc();
                 log.error("Callback failed", error);
             }

--- a/src/main/resources/kafka-partition-availability-benchmark.properties
+++ b/src/main/resources/kafka-partition-availability-benchmark.properties
@@ -5,7 +5,9 @@
 # For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
 #
 
-default_topic_prefix = default
+# If you set this to "use_hostname", it magically changes to the hostname, as
+# determined by java.net.InetAddress.getLocalHost().getHostName()
+default_topic_prefix = use_hostname
 
 num_topics = 15
 num_concurrent_topic_creations = 1

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -8,3 +8,4 @@
 org.slf4j.simpleLogger.showDateTime = true
 org.slf4j.simpleLogger.dateTimeFormat = dd-MM-YYYY HH:mm:ss.SSS
 org.slf4j.simpleLogger.levelInBrackets = true
+# org.slf4j.simpleLogger.defaultLogLevel  = debug


### PR DESCRIPTION
* Tinker with metrics around thread waiting for producing
* Change the default topic handling to use a magic name, which will
automatically use the hostname of the machine, if possible to generate
topic names
* Export default prometheus JVM metrics, things like JVM stats / etc
* Handle use case of less a RF of 2
* Callbacks to track producer message time
* Force flushing to make producer metrics calculations seems saner
* Logging changes
* sync dashboard